### PR TITLE
integrate real ESP32 BH1750 sensor into live ELPMS system

### DIFF
--- a/api/iot_readings.php
+++ b/api/iot_readings.php
@@ -1,0 +1,90 @@
+<?php
+// Receives sensor readings directly from the ESP32 device via HTTP POST.
+// Accepts application/x-www-form-urlencoded (ESP32 default format).
+// Saves to light_logs and updates the buildings table.
+// Does NOT require login - uses a device token instead.
+
+require_once __DIR__ . '/../config/db.php';
+
+header('Content-Type: application/json');
+
+// ─── Simple device token check ────────────────────────────────────────────────
+// Must match the token in the ESP32 sketch
+define('IOT_TOKEN', 'elpms_iot_2026');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['success' => false, 'message' => 'Method not allowed']);
+    exit;
+}
+
+// Validate token
+$token = $_POST['token'] ?? '';
+if ($token !== IOT_TOKEN) {
+    http_response_code(401);
+    echo json_encode(['success' => false, 'message' => 'Unauthorized']);
+    exit;
+}
+
+// ─── Validate required fields ─────────────────────────────────────────────────
+$buildingId = isset($_POST['building_id']) ? (int)$_POST['building_id']  : 0;
+$lux        = isset($_POST['lux'])         ? (float)$_POST['lux']        : null;
+$deviceId   = isset($_POST['device_id'])   ? trim($_POST['device_id'])   : '';
+
+if (!$buildingId || $lux === null || !$deviceId) {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'message' => 'building_id, lux, and device_id are required']);
+    exit;
+}
+
+if ($lux < 0 || $lux > 100000) {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'message' => 'Invalid lux value']);
+    exit;
+}
+
+// ─── Classify pollution level ─────────────────────────────────────────────────
+if ($lux <= 50) {
+    $pollutionLevel = 'low';
+} elseif ($lux <= 150) {
+    $pollutionLevel = 'moderate';
+} else {
+    $pollutionLevel = 'high';
+}
+
+// ─── Determine time of day (Philippine Standard Time) ─────────────────────────
+// db.php already sets timezone to Asia/Manila
+$hour      = (int)date('H');
+$timeOfDay = ($hour >= 6 && $hour < 18) ? 'day' : 'night';
+
+// ─── Save to database ─────────────────────────────────────────────────────────
+try {
+    // Insert into light_logs
+    $pdo->prepare(
+        "INSERT INTO light_logs (building_id, device_id, lux, pollution_level, time_of_day, online)
+         VALUES (?, ?, ?, ?, ?, 1)"
+    )->execute([$buildingId, $deviceId, $lux, $pollutionLevel, $timeOfDay]);
+
+    // Update buildings table so dashboard reflects latest reading
+    $pdo->prepare(
+        "UPDATE buildings SET lux = ?, pollution_level = ?, online = 1 WHERE id = ?"
+    )->execute([$lux, $pollutionLevel, $buildingId]);
+
+    echo json_encode([
+        'success' => true,
+        'message' => 'Reading saved',
+        'data'    => [
+            'building_id'     => $buildingId,
+            'device_id'       => $deviceId,
+            'lux'             => $lux,
+            'pollution_level' => $pollutionLevel,
+            'time_of_day'     => $timeOfDay,
+            'timestamp'       => date('Y-m-d H:i:s'),
+        ]
+    ]);
+
+} catch (PDOException $e) {
+    http_response_code(500);
+    echo json_encode(['success' => false, 'message' => $e->getMessage()]);
+}
+?>

--- a/config/schema_update.sql
+++ b/config/schema_update.sql
@@ -11,3 +11,16 @@ ALTER TABLE activity_log
 ADD COLUMN IF NOT EXISTS page VARCHAR(255) DEFAULT NULL AFTER detail,
 ADD COLUMN IF NOT EXISTS ip_address VARCHAR(45) DEFAULT NULL AFTER page,
 ADD COLUMN IF NOT EXISTS browser VARCHAR(45) DEFAULT NULL AFTER ip_address;
+
+-- IoT Integration: add device and time_of_day tracking to light_logs
+ALTER TABLE light_logs
+ADD COLUMN IF NOT EXISTS device_id VARCHAR(50) DEFAULT NULL AFTER building_id,
+ADD COLUMN IF NOT EXISTS time_of_day ENUM('day','night') NOT NULL DEFAULT 'day' AFTER pollution_level;
+
+-- Update existing records based on their recorded_at time
+-- Day: 6:00 AM to 5:59 PM | Night: 6:00 PM to 5:59 AM
+UPDATE light_logs
+SET time_of_day = CASE
+    WHEN HOUR(recorded_at) >= 6 AND HOUR(recorded_at) < 18 THEN 'day'
+    ELSE 'night'
+END;

--- a/esp32_elpms/esp32_elpms.ino
+++ b/esp32_elpms/esp32_elpms.ino
@@ -1,0 +1,193 @@
+/**
+ * ELPMS - ESP32 Light Sensor
+ * BH1750 → ESP32 → ics-dev.io/hayag/api/iot_readings.php
+ *
+ * Wiring:
+ * BH1750  ->  ESP32
+ * VCC     ->  3.3V
+ * GND     ->  GND
+ * SDA     ->  GPIO 21
+ * SCL     ->  GPIO 22
+ * ADDR    ->  GND
+ */
+
+#include <WiFi.h>
+#include <WiFiClientSecure.h>
+#include <HTTPClient.h>
+#include <Wire.h>
+#include <BH1750.h>
+
+// ─── WiFi Configuration ───────────────────────────────────────────────────────
+const char* ssid     = "Wifi name here";      // Must be 2.4GHz
+const char* password = "Wifi password here";
+
+// ─── Server Configuration ─────────────────────────────────────────────────────
+const char* serverUrl = "https://ics-dev.io/hayag/api/iot_readings.php";
+
+// ─── Device Configuration ─────────────────────────────────────────────────────
+const char* deviceId   = "ESP32_ICS_LAB";
+const int   buildingId = 6;               // ICS Laboratory
+const char* iotToken   = "elpms_iot_2026";
+
+// ─── Timing ───────────────────────────────────────────────────────────────────
+const unsigned long READING_INTERVAL    = 5000;   // 5 seconds
+const unsigned long WIFI_RETRY_INTERVAL = 10000;  // 10 seconds
+const int           MAX_WIFI_RETRIES    = 5;
+
+// ─── Pin ──────────────────────────────────────────────────────────────────────
+#define STATUS_LED 2
+
+// ─── Globals ──────────────────────────────────────────────────────────────────
+BH1750 lightMeter;
+
+unsigned long lastReadingTime   = 0;
+unsigned long lastWifiRetryTime = 0;
+int           wifiRetryCount    = 0;
+bool          sensorReady       = false;
+
+// =============================================================================
+void setup() {
+    Serial.begin(115200);
+    Serial.println("\n=== ELPMS IoT Sensor ===");
+
+    pinMode(STATUS_LED, OUTPUT);
+    blinkLED(3, 200);
+
+    Wire.begin(21, 22);
+
+    if (lightMeter.begin(BH1750::CONTINUOUS_HIGH_RES_MODE)) {
+        sensorReady = true;
+        Serial.println("BH1750 ready");
+    } else {
+        Serial.println("ERROR: BH1750 not found — check wiring");
+    }
+
+    connectWiFi();
+}
+
+// =============================================================================
+void loop() {
+    if (WiFi.status() != WL_CONNECTED) {
+        handleWiFiDisconnect();
+    }
+
+    if (millis() - lastReadingTime >= READING_INTERVAL) {
+        lastReadingTime = millis();
+
+        if (!sensorReady) {
+            Serial.println("Sensor not ready — skipping");
+            // Retry sensor init
+            if (lightMeter.begin(BH1750::CONTINUOUS_HIGH_RES_MODE)) {
+                sensorReady = true;
+                Serial.println("Sensor recovered");
+            }
+            return;
+        }
+
+        float lux = lightMeter.readLightLevel();
+
+        if (lux < 0 || isnan(lux) || isinf(lux) || lux > 100000) {
+            Serial.print("Invalid reading: ");
+            Serial.println(lux);
+            return;
+        }
+
+        Serial.print("Lux: ");
+        Serial.println(lux, 2);
+
+        if (WiFi.status() == WL_CONNECTED) {
+            sendReading(lux);
+        } else {
+            Serial.println("WiFi not connected — skipping send");
+        }
+    }
+
+    delay(100);
+}
+
+// =============================================================================
+void connectWiFi() {
+    Serial.print("Connecting to WiFi: ");
+    Serial.println(ssid);
+    WiFi.begin(ssid, password);
+
+    int attempts = 0;
+    while (WiFi.status() != WL_CONNECTED && attempts < 20) {
+        delay(500);
+        Serial.print(".");
+        attempts++;
+    }
+
+    if (WiFi.status() == WL_CONNECTED) {
+        wifiRetryCount = 0;
+        Serial.println("\nWiFi connected: " + WiFi.localIP().toString());
+        digitalWrite(STATUS_LED, HIGH);
+    } else {
+        Serial.println("\nWiFi failed");
+        digitalWrite(STATUS_LED, LOW);
+    }
+}
+
+// =============================================================================
+void handleWiFiDisconnect() {
+    unsigned long now = millis();
+    if (now - lastWifiRetryTime >= WIFI_RETRY_INTERVAL) {
+        lastWifiRetryTime = now;
+        wifiRetryCount++;
+        if (wifiRetryCount <= MAX_WIFI_RETRIES) {
+            Serial.println("WiFi retry: " + String(wifiRetryCount));
+            connectWiFi();
+        } else {
+            Serial.println("Max retries reached — restarting");
+            delay(3000);
+            ESP.restart();
+        }
+    }
+}
+
+// =============================================================================
+void sendReading(float lux) {
+    WiFiClientSecure client;
+    client.setInsecure();
+    HTTPClient http;
+
+    if (!http.begin(client, serverUrl)) {
+        Serial.println("HTTP begin failed");
+        return;
+    }
+
+    http.addHeader("Content-Type", "application/x-www-form-urlencoded");
+    http.addHeader("User-Agent", "ESP32-ELPMS/1.0");
+    http.setTimeout(10000);
+
+    String postData = "token="       + String(iotToken)   +
+                      "&device_id="  + String(deviceId)   +
+                      "&building_id="+ String(buildingId) +
+                      "&lux="        + String(lux, 2);
+
+    int code = http.POST(postData);
+
+    Serial.print("HTTP: ");
+    Serial.print(code);
+    Serial.print(" | ");
+    Serial.println(code == 200 ? "SUCCESS" : "FAILED");
+
+    if (code == 200) {
+        Serial.println(http.getString());
+        blinkLED(2, 100);
+    } else {
+        blinkLED(5, 50);
+    }
+
+    http.end();
+}
+
+// =============================================================================
+void blinkLED(int count, int delayMs) {
+    for (int i = 0; i < count; i++) {
+        digitalWrite(STATUS_LED, HIGH);
+        delay(delayMs);
+        digitalWrite(STATUS_LED, LOW);
+        delay(delayMs);
+    }
+}

--- a/login.php
+++ b/login.php
@@ -45,6 +45,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action']) && $_POST['
             };
             header('Location: ' . $dest);
             exit;
+            /*
+            $log = "[ELPMS] LOGIN - User: {$user['name']} | Email: {$user['email']} | Role: {$user['role']} | ID: {$user['id']}";
+            echo "<script>console.log(" . json_encode($log) . "); window.location='" . $dest . "';</script>";
+            exit;
+            */
         } else {
             $errors[] = 'Invalid email or password.';
             // Log failed attempt if the email exists (wrong password)
@@ -89,6 +94,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['action']) && $_POST['
             $_SESSION['user_id'] = $newUserId;
             logActivity($pdo, 'registered', "New account registered: $name ($email)");
             unset($_SESSION['user_id']);
+
+            /*
+            $log = "[ELPMS] REGISTER - Name: $name | Email: $email | ID: $newUserId";
+            echo "<script>console.log(" . json_encode($log) . ")</script>";
+            */
+            
             $success = 'Account created! You can now log in.';
             $tab = 'login';
         }


### PR DESCRIPTION
## Summary
Integrates the physical ESP32 + BH1750 light sensor into the live ELPMS 
system hosted at ics-dev.io. Real sensor readings from the ICS Laboratory 
(building_id = 6) are now being stored directly into the live database. 
This replaces the simulated readings for building 6 with actual IoT data.

## Changes Made

### New File api/iot_readings.php
- Dedicated API endpoint for ESP32 POST requests
- Accepts application/x-www-form-urlencoded format (ESP32 native)
- Token-based authentication using IOT_TOKEN constant
  (does not require user login)
- Validates all incoming fields: building_id, lux, device_id
- Validates lux range (0 to 100,000) to reject invalid readings
- Classifies pollution level from raw lux:
    low      → lux <= 50
    moderate → lux <= 150
    high     → lux > 150
- Determines time_of_day automatically using Asia/Manila timezone:
    day   → 6:00 AM to 5:59 PM
    night → 6:00 PM to 5:59 AM
- Inserts into light_logs with device_id, building_id, lux,
  pollution_level, time_of_day
- Updates buildings table immediately so dashboard reflects
  latest reading in real time

### Database Migration - migration_time_of_day.sql
- Added time_of_day ENUM('day', 'night') column to light_logs
- Existing records backfilled based on recorded_at timestamp

### New File - esp32_elpms.ino
- Production ESP32 sketch for ICS Laboratory sensor
- Points directly to https://ics-dev.io/hayag/api/iot_readings.php
- device_id = ESP32_ICS_LAB
- building_id = 6 (ICS Laboratory)
- Sends readings every 5 seconds via HTTPS
- Uses WiFiClientSecure with setInsecure() for SSL
- Includes IOT_TOKEN in every POST request
- Auto-reconnects WiFi on disconnect
- Restarts via ESP.restart() after max retries exceeded

## Testing
- ESP32 confirmed sending HTTP 200 to live server
- Live database (u442411629_hayag) receiving real readings
- device_id, building_id, pollution_level, time_of_day all
  correctly populated
- Timezone confirmed as Asia/Manila (set in config/db.php)
- Simulated readings for buildings 1-5 and 7 preserved
  and unaffected

## Notes
- Simulation (main.js) intentionally kept running for buildings
  1-5 and 7 since only ICS Lab has a physical sensor deployed
- IOT_TOKEN hardcoded for now - should be moved to environment
  variable or .env file before final production deployment
- time_of_day thresholds use Philippine Standard Time (UTC+8)
  which is already set in config/db.php

## Closes Issues
Closes #21 Real sensor integration into live system